### PR TITLE
Refine tile model + api response

### DIFF
--- a/adventure/api/views.py
+++ b/adventure/api/views.py
@@ -18,11 +18,7 @@ def response_data(player, errors=None):
 
     return {
         "player": player.as_dict(),
-        "tile": {
-            "name": tile.name,
-            "description": tile.description,
-            "players": tile.get_players_in_tile(),
-        },
+        "tile": tile.as_dict(),
         "errors": errors,
     }
 

--- a/adventure/api/views.py
+++ b/adventure/api/views.py
@@ -57,32 +57,10 @@ def move(request):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
-    elif requested_direction == "n":
-
-        next_tile = tile.to_n
-
-    elif requested_direction == "s":
-
-        next_tile = tile.to_s
-
-    elif requested_direction == "e":
-
-        next_tile = tile.to_e
-
-    elif requested_direction == "w":
-
-        next_tile = tile.to_w
-
     else:
 
-        print("HOW DID YOU GET HERE!?")
-        return Response(
-            data=response_data(
-                player=player,
-                errors=["We done programmed this wrong."],
-            ),
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        side = sides[requested_direction]["to"]
+        next_tile = getattr(tile, f"to_{side}")
 
     if next_tile is not None:
 

--- a/adventure/api/views.py
+++ b/adventure/api/views.py
@@ -7,16 +7,9 @@ from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from adventure.models import Tile, Player
+from adventure.models import Tile, Player, sides
 
 ############################################################
-
-directions = {
-    "n": "north",
-    "s": "south",
-    "e": "east",
-    "w": "west",
-}
 
 
 def response_data(player, errors=None):
@@ -58,7 +51,7 @@ def move(request):
     requested_direction = request.data["direction"]
     next_tile = None
 
-    if requested_direction not in directions.keys():
+    if requested_direction not in sides.keys():
 
         return Response(
             data=response_data(

--- a/adventure/api/views.py
+++ b/adventure/api/views.py
@@ -1,13 +1,12 @@
 ############################################################
 
 from django.views.decorators.csrf import csrf_exempt
-from django.contrib.auth.models import User
 
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from adventure.models import Tile, Player, sides
+from adventure.models import sides
 
 ############################################################
 

--- a/adventure/api/views.py
+++ b/adventure/api/views.py
@@ -12,13 +12,20 @@ from adventure.models import Tile, Player, sides
 ############################################################
 
 
-def response_data(player, errors=None):
+def response_data(player, messages=None, errors=None):
+
+    if messages is None:
+        messages = []
+
+    if errors is None:
+        errors = []
 
     tile = player.get_current_tile()
 
     return {
         "player": player.as_dict(),
         "tile": tile.as_dict(),
+        "messages": messages,
         "errors": errors,
     }
 
@@ -31,7 +38,12 @@ def start(request):
     player = user.player
 
     return Response(
-        data=response_data(player=player),
+        data=response_data(
+            player=player,
+            messages=[
+                "You just started your adventure.",
+            ],
+        ),
         status=status.HTTP_202_ACCEPTED,
     )
 
@@ -52,7 +64,12 @@ def move(request):
         return Response(
             data=response_data(
                 player=player,
-                errors=["You can't move that way."],
+                messages=[
+                    f"You can't move in the direction \"{requested_direction}\".",
+                ],
+                errors=[
+                    f"You can't move in the direction \"{requested_direction}\".",
+                ],
             ),
             status=status.HTTP_400_BAD_REQUEST,
         )
@@ -62,13 +79,20 @@ def move(request):
         side = sides[requested_direction]["to"]
         next_tile = getattr(tile, f"to_{side}")
 
+    requested_direction_name = sides[requested_direction]["name"]
+
     if next_tile is not None:
 
         player.current_tile = next_tile
         player.save()
 
         return Response(
-            data=response_data(player=player),
+            data=response_data(
+                player=player,
+                messages=[
+                    f"You move {requested_direction_name}.",
+                ],
+            ),
             status=status.HTTP_202_ACCEPTED,
         )
 
@@ -77,7 +101,12 @@ def move(request):
         return Response(
             data=response_data(
                 player=player,
-                errors=["You can't move that way."],
+                messages=[
+                    f"You can't move {requested_direction_name}.",
+                ],
+                errors=[
+                    f"You can't move {requested_direction_name}.",
+                ],
             ),
             status=status.HTTP_400_BAD_REQUEST,
         )
@@ -93,7 +122,12 @@ def speak(request):
     return Response(
         data=response_data(
             player=player,
-            errors=["You can't speak yet."],
+            messages=[
+                "You can't speak yet.",
+            ],
+            errors=[
+                "You can't speak yet.",
+            ],
         ),
         status=status.HTTP_501_NOT_IMPLEMENTED,
     )

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -105,15 +105,16 @@ class Tile(models.Model):
 
         self.save()
 
-            self.to_e = to_tile
+    def connect_from(self, from_side, from_tile):
 
-        elif to_side == "w":
+        if from_side not in sides.keys():
 
-            self.to_w = to_tile
+            raise Exception("connect_from.InvalidSide")
 
         else:
 
-            raise Exception("connect_to.ProgrammerError")
+            side = sides[from_side]["from"]
+            setattr(self, f"to_{side}", from_tile)
 
         self.save()
 

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -11,10 +11,26 @@ from rest_framework.authtoken.models import Token
 ############################################################
 
 sides = {
-    "n": "north",
-    "e": "east",
-    "s": "south",
-    "w": "west",
+    "n": {
+        "name": "north",
+        "to": "n",
+        "from": "s",
+    },
+    "e": {
+        "name": "east",
+        "to": "e",
+        "from": "w",
+    },
+    "s": {
+        "name": "south",
+        "to": "s",
+        "from": "n",
+    },
+    "w": {
+        "name": "west",
+        "to": "w",
+        "from": "e",
+    },
 }
 
 corners = {
@@ -82,15 +98,12 @@ class Tile(models.Model):
 
             raise Exception("connect_to.InvalidSide")
 
-        elif to_side == "n":
+        else:
 
-            self.to_n = to_tile
+            side = sides[to_side]["to"]
+            setattr(self, f"to_{side}", to_tile)
 
-        elif to_side == "s":
-
-            self.to_s = to_tile
-
-        elif to_side == "e":
+        self.save()
 
             self.to_e = to_tile
 

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -96,6 +96,19 @@ class Tile(models.Model):
 
         return (getattr(self, f"to_{side}") is not None)
 
+    def as_dict(self):
+
+        data = {
+            "name": self.name,
+            "description": self.description,
+            "players": self.get_players_in_tile(),
+        }
+
+        for side in sides.keys():
+            data[f"to_{side}"] = self.has_to_side(side)
+
+        return data
+
     def connect_to(self, to_side, to_tile):
 
         if to_side not in sides.keys():

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -10,6 +10,22 @@ from rest_framework.authtoken.models import Token
 
 ############################################################
 
+sides = {
+    "n": "north",
+    "e": "east",
+    "s": "south",
+    "w": "west",
+}
+
+corners = {
+    "nw": "north-west",
+    "ne": "north-east",
+    "se": "south-east",
+    "sw": "south-west",
+}
+
+############################################################
+
 
 class Tile(models.Model):
 
@@ -60,27 +76,31 @@ class Tile(models.Model):
 
         return f"{self.name} [{self.id}]"
 
-    def connect_to(self, direction, destination_tile):
+    def connect_to(self, to_side, to_tile):
 
-        if direction == "n":
+        if to_side not in sides.keys():
 
-            self.to_n = destination_tile
+            raise Exception("connect_to.InvalidSide")
 
-        elif direction == "s":
+        elif to_side == "n":
 
-            self.to_s = destination_tile
+            self.to_n = to_tile
 
-        elif direction == "e":
+        elif to_side == "s":
 
-            self.to_e = destination_tile
+            self.to_s = to_tile
 
-        elif direction == "w":
+        elif to_side == "e":
 
-            self.to_w = destination_tile
+            self.to_e = to_tile
+
+        elif to_side == "w":
+
+            self.to_w = to_tile
 
         else:
 
-            raise Exception("connect_to.InvalidDirection")
+            raise Exception("connect_to.ProgrammerError")
 
         self.save()
 

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -92,6 +92,10 @@ class Tile(models.Model):
 
         return f"{self.name} [{self.id}]"
 
+    def has_to_side(self, side):
+
+        return (getattr(self, f"to_{side}") is not None)
+
     def connect_to(self, to_side, to_tile):
 
         if to_side not in sides.keys():

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -98,16 +98,17 @@ class Tile(models.Model):
 
     def as_dict(self):
 
-        data = {
+        tile_dict = {
             "name": self.name,
             "description": self.description,
-            "players": self.get_players_in_tile(),
         }
 
         for side in sides.keys():
-            data[f"to_{side}"] = self.has_to_side(side)
+            tile_dict[f"to_{side}"] = self.has_to_side(side)
 
-        return data
+        tile_dict["players"] = self.get_players_in_tile()
+
+        return tile_dict
 
     def connect_to(self, to_side, to_tile):
 
@@ -174,10 +175,12 @@ class Player(models.Model):
 
     def as_dict(self):
 
-        return {
+        player_dict = {
             "uuid": self.uuid,
             "name": self.user.username,
         }
+
+        return player_dict
 
     def start_adventure(self):
 


### PR DESCRIPTION
Make `Tile` operations more programmatic. Make requests to `api/adventure/*` return whether the current tile is connected. Return messages detailing what has happened. The new response body looks like.

```yaml
{
    "player": {
        "uuid": string,
        "name": string,
    },
    "tile": {
        "name": string,
        "description": string,
        "to_n": boolean,
        "to_e": boolean,
        "to_s": boolean,
        "to_w": boolean,
        "players": list(
            {
                "uuid": string,
                "name": string,
            },
        ),
    },
    "messages": list(string),
    "errors": list(string),
}
```

**_NOTE:_** `"messages"` and `"errors"` will never be `null`. If there are no errors, then `"errors"` will be an empty list.