### PR TITLE
Return tile drawing, part 2

### DIFF
--- a/adventure/models.py
+++ b/adventure/models.py
@@ -109,8 +109,10 @@ class Tile(models.Model):
         for side in sides.keys():
             tile_dict[f"to_{side}"] = self.has_to_side(side)
 
-        tile_dict["pixel_grid"] = pixel_grid_of_tile(self, show_player=True)
-        tile_dict["pixel_rows"] = pixel_rows_of_tile(self, show_player=True)
+        tile_dict["drawing"] = {
+            "grid": pixel_grid_of_tile(self, show_player=True),
+            "rows": pixel_rows_of_tile(self, show_player=True),
+        }
 
         tile_dict["players"] = self.get_players_in_tile()
 

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -9,7 +9,11 @@ from django.contrib.auth.models import User
 from django.dispatch import receiver
 from rest_framework.authtoken.models import Token
 
-from tools.tile_drawing import pixel_grid_of_tile, pixel_rows_of_tile
+from tools.tile_drawing import (
+    pixel_grid_of_tile,
+    pixel_rows_of_tile,
+    draw_tile,
+)
 
 ############################################################
 
@@ -112,6 +116,7 @@ class Tile(models.Model):
         tile_dict["drawing"] = {
             "grid": pixel_grid_of_tile(self, show_player=True),
             "rows": pixel_rows_of_tile(self, show_player=True),
+            "string": draw_tile(self, show_player=True),
         }
 
         tile_dict["players"] = self.get_players_in_tile()

--- a/tools/tile_drawing.py
+++ b/tools/tile_drawing.py
@@ -95,7 +95,7 @@ def pixel_rows_of_tile_list(tile_list):
 
 def draw_tile(tile, show_player=False):
 
-    return "\n".join(pixel_rows_of_tile(tile, show_player=False))
+    return "\n".join(pixel_rows_of_tile(tile, show_player=show_player))
 
 
 def draw_tile_row(tile_row):


### PR DESCRIPTION
Update data returned from endpoints to also provide a string ready for `<pre>` tags.

Data structure now looks like:

```yaml
{
    "player": {
        "uuid": string,
        "name": string,
    },
    "tile": {
        "name": string,
        "description": string,
        "to_n": boolean,
        "to_e": boolean,
        "to_s": boolean,
        "to_w": boolean,
        "drawing": {
            "grid": list(list(string)),
            "rows": list(string),
            "string": string, 
        }
        "players": list(
            {
                "uuid": string,
                "name": string,
            },
        ),
    },
    "messages": list(string),
    "errors": list(string),
}
```
